### PR TITLE
Use relative URL for project pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,4 +4,4 @@ title = "Home page"
 
 This bare markdown page has **bold** and *italics* formatting.
 
-It links to <a href="/present">a hugo-reveal presentation</a> and an associated <a href="/present-info">bare markdown page</a>.
+It links to <a href="./present">a hugo-reveal presentation</a> and an associated <a href="./present-info">bare markdown page</a>.


### PR DESCRIPTION
Thanks for your example.  This helps learning how Hugo works.

I've cloned your repo to Framagit and tested your repo there as a GitLab project page.  Clicking the links in the home page gives a 404 error since the link `href` is shown as `/present`, which is expanded to `https://<domain-name>/present` instead of `https://<domain-name>/<project-name>/present`.  This can be solved by using the relative URL instead.

You may test the artifacts generated by the Framagit's GitLab CD/CI to see the rendering of this site as a GitLab project page:
https://framagit.org/VincentTam/hugo-demo/-/jobs/404197/artifacts/browse/public/